### PR TITLE
Add func for Safe Division to avoid NaN

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+Copyright (c) 2013 Yukinari Toyota
+
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
 the Software without restriction, including without limitation the rights to

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,3 @@
-Copyright (c) 2013 Yukinari Toyota
-
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
 the Software without restriction, including without limitation the rights to

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
-## Forked from t-yuki
-
-This is a **fork** of https://github.com/boumenot/gocover-cobertura.
+## Forked from [Christopher Boumenot (boumenot)](https://github.com/boumenot)
 
 At the time of this writing the repository appears to be on *pause* with
-several outstanding PRs, and forks with interesting contributions.  This
-repo consolidates those outstanding forks, and combines them into one repo.
+several outstanding PRs, issues and forks with interesting contributions.
+
+This repo aims to add improvements so that it can be used by our services.
 
 go tool cover XML (Cobertura) export
 ====================================
@@ -18,15 +17,15 @@ Installation
 
 Just type the following to install the program and its dependencies:
 
-    $ go get github.com/boumenot/gocover-cobertura
+    $ go get github.com/bountylabs/gocover-cobertura
 
 Usage
 -----
 
 `gocover-cobertura` reads from the standard input:
 
-    $ go test -coverprofile=coverage.txt -covermode count github.com/gorilla/mux
-    $ gocover-cobertura < coverage.txt > coverage.xml
+    $ go test -coverprofile=coverage.out -covermode count ./
+    $ gocover-cobertura < coverage.out > coverage.xml
     
 Note that you should run this from the directory which holds your `go.mod` file.
 
@@ -41,11 +40,11 @@ Some flags can be passed (each flag should only be used once):
 
   ignore directories matching `PATTERN` regular expression. Full
   directory names are matched, as
-  `github.com/boumenot/gocover-cobertura` (and so `github.com/boumenot`
+  `github.com/bountylabs /gocover-cobertura` (and so `github.com/bountylabs`
   and `github.com`), examples of use:
   ```
   # A specific directory
-  -ignore-dirs '^github\.com/boumenot/gocover-cobertura/testdata$'
+  -ignore-dirs '^github\.com/bountylabs/gocover-cobertura/testdata$'
   # All directories autogen and any of their subdirs
   -ignore-dirs '/autogen$'
   ```
@@ -53,11 +52,11 @@ Some flags can be passed (each flag should only be used once):
 - `-ignore-files PATTERN`
 
   ignore files matching `PATTERN` regular expression. Full file names
-  are matched, as `github.com/boumenot/gocover-cobertura/profile.go`,
+  are matched, as `github.com/bountylabs/gocover-cobertura/profile.go`,
   examples of use:
   ```
   # A specific file
-  -ignore-files '^github\.com/boumenot/gocover-cobertura/profile\.go$'
+  -ignore-files '^github\.com/bountylabs/gocover-cobertura/profile\.go$'
   # All files ending with _gen.go
   -ignore-files '_gen\.go$'
   # All files in a directory autogen (or any of its subdirs)
@@ -70,11 +69,7 @@ Some flags can be passed (each flag should only be used once):
   indicating that the file has been automatically generated. See
   `genCodeRe` regexp in [ignore.go](ignore.go).
 
-~~Authors~~Merger
--------
-
-[Christopher Boumenot (boumenot)](https://github.com/boumenot)
-
+  
 Thanks
 ------
 

--- a/cobertura.go
+++ b/cobertura.go
@@ -158,8 +158,7 @@ func (pkg Package) NumLinesWithHits() (numLinesWithHits int64) {
 // HitRate returns a float32 from 0.0 to 1.0 representing what fraction of lines
 // have hits
 func (cov Coverage) HitRate() float32 {
-	result := safeDivide(float32(cov.NumLinesWithHits()), float32(cov.NumLines()))
-	return result
+	return safeDivide(float32(cov.NumLinesWithHits()), float32(cov.NumLines()))
 }
 
 // NumLines returns the number of lines

--- a/cobertura.go
+++ b/cobertura.go
@@ -61,7 +61,7 @@ type Lines []*Line
 // HitRate returns a float32 from 0.0 to 1.0 representing what fraction of lines
 // have hits
 func (lines Lines) HitRate() (hitRate float32) {
-	return float32(lines.NumLinesWithHits()) / float32(len(lines))
+	return safeDivide(float32(lines.NumLinesWithHits()), float32(len(lines)))
 }
 
 // NumLines returns the number of lines
@@ -114,7 +114,7 @@ func (method Method) NumLinesWithHits() int64 {
 // HitRate returns a float32 from 0.0 to 1.0 representing what fraction of lines
 // have hits
 func (class Class) HitRate() float32 {
-	return float32(class.NumLinesWithHits()) / float32(class.NumLines())
+	return safeDivide(float32(class.NumLinesWithHits()), float32(class.NumLines()))
 }
 
 // NumLines returns the number of lines
@@ -136,7 +136,7 @@ func (class Class) NumLinesWithHits() (numLinesWithHits int64) {
 // HitRate returns a float32 from 0.0 to 1.0 representing what fraction of lines
 // have hits
 func (pkg Package) HitRate() float32 {
-	return float32(pkg.NumLinesWithHits()) / float32(pkg.NumLines())
+	return safeDivide(float32(pkg.NumLinesWithHits()), float32(pkg.NumLines()))
 }
 
 // NumLines returns the number of lines
@@ -158,7 +158,8 @@ func (pkg Package) NumLinesWithHits() (numLinesWithHits int64) {
 // HitRate returns a float32 from 0.0 to 1.0 representing what fraction of lines
 // have hits
 func (cov Coverage) HitRate() float32 {
-	return float32(cov.NumLinesWithHits()) / float32(cov.NumLines())
+	result := safeDivide(float32(cov.NumLinesWithHits()), float32(cov.NumLines()))
+	return result
 }
 
 // NumLines returns the number of lines
@@ -175,4 +176,11 @@ func (cov Coverage) NumLinesWithHits() (numLinesWithHits int64) {
 		numLinesWithHits += pkg.NumLinesWithHits()
 	}
 	return numLinesWithHits
+}
+
+func safeDivide(a, b float32) float32 {
+	if b == 0 {
+		return float32(0)
+	}
+	return a / b
 }

--- a/gocover-cobertura_test.go
+++ b/gocover-cobertura_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"testing"
 


### PR DESCRIPTION
When the coverage output file contains contains no data, the following invalid XML will be created:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
<coverage line-rate="NaN" branch-rate="0" version="" timestamp="1623176744081" lines-covered="0" lines-valid="0" branches-covered="0" branches-valid="0" complexity="0">
    <sources>
        <source></source>
    </sources>
    <packages></packages>
</coverage>
```

The issue is cased by dividing by zero when calculating the `line-rate` attribute.